### PR TITLE
Update to 1.21

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ It also parses passed IP addresses so the server is aware of the real player IP 
 
 ### Compatibility
 
-TCPShield is compatible with Spigot / CraftBukkit, BungeeCord and Velocity.
+TCPShield is compatible with Spigot / CraftBukkit, BungeeCord, Velocity, and Fabric.
 
 When using Spigot / CraftBukkit, [ProtocolLib](https://github.com/aadnk/ProtocolLib) needs to be installed.
 

--- a/build.gradle
+++ b/build.gradle
@@ -26,7 +26,7 @@ plugins {
 // --
 // Variables
 // --
-version = '2.6.1'
+version = '2.7.0'
 group = 'net.tcpshield.tcpshield'
 archivesBaseName = 'TCPShield'
 
@@ -95,7 +95,7 @@ repositories {
 dependencies {
     // Bukkit
     compileOnly group: 'org.spigotmc', name: 'spigot-api', version: '1.11-R0.1-SNAPSHOT'
-    compileOnly group: 'com.comphenix.protocol', name: 'ProtocolLib', version: '5.0.0-SNAPSHOT'
+    compileOnly group: 'com.comphenix.protocol', name: 'ProtocolLib', version: '5.1.0'
 
     // Paper
     compileOnly group: 'com.destroystokyo.paper', name: 'paper-api', version: '1.15.2-R0.1-SNAPSHOT'

--- a/build.gradle
+++ b/build.gradle
@@ -26,7 +26,7 @@ plugins {
 // --
 // Variables
 // --
-version = '2.7.0'
+version = '2.8.0'
 group = 'net.tcpshield.tcpshield'
 archivesBaseName = 'TCPShield'
 
@@ -60,8 +60,8 @@ sourceSets {
 }
 
 compileJava {
-    sourceCompatibility = "8"
-    targetCompatibility = "8"
+    sourceCompatibility = 17
+    targetCompatibility = 17
     options.encoding = 'UTF-8'
 }
 
@@ -82,10 +82,7 @@ repositories {
         url = 'https://oss.sonatype.org/content/repositories/snapshots'
     }
     maven {
-        url = 'https://papermc.io/repo/repository/maven-public/'
-    }
-    maven {
-        url = 'https://repo.velocitypowered.com/snapshots/'
+        url = 'https://repo.papermc.io/repository/maven-public/'
     }
     maven {
         url = "https://repo.opencollab.dev/maven-snapshots/"
@@ -94,17 +91,16 @@ repositories {
 
 dependencies {
     // Bukkit
-    compileOnly group: 'org.spigotmc', name: 'spigot-api', version: '1.11-R0.1-SNAPSHOT'
     compileOnly group: 'com.comphenix.protocol', name: 'ProtocolLib', version: '5.1.0'
 
-    // Paper
-    compileOnly group: 'com.destroystokyo.paper', name: 'paper-api', version: '1.15.2-R0.1-SNAPSHOT'
+    // Paper - 1.19.4 so we can bump from JDK 8 -> JDK 17, using 1.20.x as a dependency would require bumping from JDK 8 -> JDK 21
+    compileOnly group: 'io.papermc.paper', name: 'paper-api', version: '1.19.4-R0.1-SNAPSHOT'
 
     // BungeeCord
     compileOnly group: 'net.md-5', name: 'bungeecord-api', version: '1.14-SNAPSHOT'
 
     // Velocity
-    compileOnly group: 'com.velocitypowered', name: 'velocity-api', version: '1.0.0-SNAPSHOT'
+    compileOnly group: 'com.velocitypowered', name: 'velocity-api', version: '3.3.0-SNAPSHOT'
 
     // Testing
     testImplementation group: 'org.junit.jupiter', name: 'junit-jupiter-api', version: '5.7.0-M1'

--- a/build.gradle
+++ b/build.gradle
@@ -21,13 +21,13 @@ buildscript {
 plugins {
     id 'java'
     id 'idea'
-    id 'fabric-loom' version '0.6-SNAPSHOT'
+    id 'fabric-loom' version '1.7-SNAPSHOT'
 }
 
 // --
 // Variables
 // --
-version = '2.8.1'
+version = '2.8.0'
 group = 'net.tcpshield.tcpshield'
 archivesBaseName = 'TCPShield'
 
@@ -107,9 +107,9 @@ dependencies {
     compileOnly group: 'com.velocitypowered', name: 'velocity-api', version: '3.3.0-SNAPSHOT'
 
     // Fabric
-    minecraft "com.mojang:minecraft:1.16.5"
-    mappings "net.fabricmc:yarn:1.16.5+build.5:v2"
-    modImplementation group: 'net.fabricmc', name: 'fabric-loader', version: '0.11.2'
+    minecraft "com.mojang:minecraft:1.21"
+    mappings "net.fabricmc:yarn:1.21+build.9"
+    modImplementation group: 'net.fabricmc', name: 'fabric-loader', version: '0.16.0'
 
     // Testing
     testImplementation group: 'org.junit.jupiter', name: 'junit-jupiter-api', version: '5.7.0-M1'

--- a/build.gradle
+++ b/build.gradle
@@ -27,7 +27,7 @@ plugins {
 // --
 // Variables
 // --
-version = '2.8.0'
+version = '2.8.1'
 group = 'net.tcpshield.tcpshield'
 archivesBaseName = 'TCPShield'
 

--- a/src/main/java/net/tcpshield/tcpshield/TCPShieldPacketHandler.java
+++ b/src/main/java/net/tcpshield/tcpshield/TCPShieldPacketHandler.java
@@ -14,6 +14,7 @@ import net.tcpshield.tcpshield.util.validation.timestamp.TimestampValidator;
 import net.tcpshield.tcpshield.util.validation.timestamp.impl.HTPDateTimestampValidator;
 
 import java.io.IOException;
+import java.lang.reflect.InvocationTargetException;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.net.UnknownHostException;

--- a/src/main/java/net/tcpshield/tcpshield/bukkit/TCPShieldBukkit.java
+++ b/src/main/java/net/tcpshield/tcpshield/bukkit/TCPShieldBukkit.java
@@ -1,5 +1,6 @@
 package net.tcpshield.tcpshield.bukkit;
 
+import java.util.logging.Logger;
 import net.tcpshield.tcpshield.TCPShieldPacketHandler;
 import net.tcpshield.tcpshield.TCPShieldPlugin;
 import net.tcpshield.tcpshield.bukkit.paper.BukkitPaper;
@@ -9,6 +10,7 @@ import net.tcpshield.tcpshield.geyser.GeyserUtils;
 import net.tcpshield.tcpshield.provider.ConfigProvider;
 import net.tcpshield.tcpshield.util.Debugger;
 import net.tcpshield.tcpshield.util.exception.phase.InitializationException;
+import org.bukkit.Bukkit;
 import org.bukkit.plugin.java.JavaPlugin;
 
 /**
@@ -31,7 +33,25 @@ public class TCPShieldBukkit extends JavaPlugin implements TCPShieldPlugin {
 
 			// check force plib option -> paper -> plib -> error
 			if (this.configProvider.preferProtocolLib() && getServer().getPluginManager().getPlugin("ProtocolLib") != null) {
-				bukkitImpl = new BukkitProtocolLib(this);
+				try {
+					String[] protocolLibVersion = getServer().getPluginManager().getPlugin("ProtocolLib").getDescription().getVersion().split("-")[0].split("\\.");
+					int major = Integer.parseInt(protocolLibVersion[0]);
+					int minor = Integer.parseInt(protocolLibVersion[1]);
+					int patch = Integer.parseInt(protocolLibVersion[2]);
+
+					String paperVersion = Bukkit.getServer().getMinecraftVersion();
+					if (major <= 5 && minor <= 2 && patch <= 1 && (paperVersion.equals("1.20.5") || paperVersion.equals("1.20.6"))) {
+						getLogger().severe("TCPShield is incompatible with ProtocolLib <= 5.2.1 on Paper 1.20.5/1.20.6 due to lack of support from ProtocolLib. Reverting to default Paper handler to prevent issues. This error can be avoided by disabling 'prefer-protocollib' in the config.");
+						bukkitImpl = new BukkitPaper(this);
+					} else {
+						bukkitImpl = new BukkitProtocolLib(this);
+					}
+				} catch (Exception t) {
+					getLogger().warning("Failed to check Paper or ProtocolLib version. This is not a critical error unless you are running Paper 1.20.5/1.20.6 with ProtocolLib version 5.2.1 or below.");
+					getDebugger().exception(t);
+
+					bukkitImpl = new BukkitProtocolLib(this);
+				}
 			} else if (BukkitImplProvider.hasPaperEvent()) {
 				bukkitImpl = new BukkitPaper(this);
 			} else if (getServer().getPluginManager().getPlugin("ProtocolLib") != null) {
@@ -70,6 +90,11 @@ public class TCPShieldBukkit extends JavaPlugin implements TCPShieldPlugin {
 	@Override
 	public ConfigProvider getConfigProvider() {
 		return configProvider;
+	}
+
+	@Override
+	public Logger getLogger() {
+		return super.getLogger();
 	}
 
 }

--- a/src/main/java/net/tcpshield/tcpshield/fabric/impl/FabricPacket.java
+++ b/src/main/java/net/tcpshield/tcpshield/fabric/impl/FabricPacket.java
@@ -5,7 +5,7 @@ import net.tcpshield.tcpshield.fabric.mixin.HandshakeC2SPacketAccessor;
 import net.tcpshield.tcpshield.provider.PacketProvider;
 import net.tcpshield.tcpshield.util.exception.manipulate.PacketManipulationException;
 
-public class FabricPacket implements PacketProvider  {
+public class FabricPacket implements PacketProvider {
 
     private final HandshakeC2SPacket handshake;
 
@@ -15,7 +15,7 @@ public class FabricPacket implements PacketProvider  {
 
     @Override
     public String getPayloadString() {
-        return ((HandshakeC2SPacketAccessor) handshake).getAddress();
+        return HandshakeC2SPacketAccessor.class.cast(handshake).getAddress();
     }
 
     @Override

--- a/src/main/java/net/tcpshield/tcpshield/fabric/impl/FabricPlayer.java
+++ b/src/main/java/net/tcpshield/tcpshield/fabric/impl/FabricPlayer.java
@@ -2,7 +2,7 @@ package net.tcpshield.tcpshield.fabric.impl;
 
 import net.minecraft.network.ClientConnection;
 import net.minecraft.network.packet.c2s.handshake.HandshakeC2SPacket;
-import net.minecraft.text.LiteralText;
+import net.minecraft.text.Text;
 import net.tcpshield.tcpshield.fabric.mixin.ClientConnectionAccessor;
 import net.tcpshield.tcpshield.provider.PlayerProvider;
 
@@ -43,6 +43,6 @@ public class FabricPlayer implements PlayerProvider {
 
     @Override
     public void disconnect() {
-        connection.disconnect(new LiteralText("Connection failed. Please try again or contact an administrator."));
+        connection.disconnect(Text.literal("Connection failed. Please try again or contact an administrator."));
     }
 }

--- a/src/main/java/net/tcpshield/tcpshield/fabric/mixin/HandshakeC2SPacketAccessor.java
+++ b/src/main/java/net/tcpshield/tcpshield/fabric/mixin/HandshakeC2SPacketAccessor.java
@@ -6,6 +6,6 @@ import org.spongepowered.asm.mixin.gen.Accessor;
 
 @Mixin(HandshakeC2SPacket.class)
 public interface HandshakeC2SPacketAccessor {
-    @Accessor
+    @Accessor("address")
     String getAddress();
 }

--- a/src/main/java/net/tcpshield/tcpshield/velocity/handler/VelocityPacket.java
+++ b/src/main/java/net/tcpshield/tcpshield/velocity/handler/VelocityPacket.java
@@ -31,7 +31,15 @@ public class VelocityPacket implements PacketProvider {
 			Class<?> inboundConnection = Class.forName("com.velocitypowered.proxy.connection.client.InitialInboundConnection");
 
 			HANDSHAKE_FIELD = ReflectionUtil.getPrivateField(inboundConnection, "handshake");
-			HOSTNAME_FIELD = ReflectionUtil.getPrivateField(Class.forName("com.velocitypowered.proxy.protocol.packet.Handshake"), "serverAddress");
+
+			Field hostnameField;
+			try {
+				hostnameField = ReflectionUtil.getPrivateField(Class.forName("com.velocitypowered.proxy.protocol.packet.HandshakePacket"), "serverAddress");
+			} catch (Exception e) {
+				hostnameField = ReflectionUtil.getPrivateField(Class.forName("com.velocitypowered.proxy.protocol.packet.Handshake"), "serverAddress");
+			}
+			HOSTNAME_FIELD = hostnameField;
+
 			CLEANED_ADDRESS_FIELD = ReflectionUtil.getPrivateField(inboundConnection, "cleanedAddress");
 		} catch (Exception e) {
 			throw new InitializationException(new ReflectionException(e));

--- a/src/main/resources/bungee.yml
+++ b/src/main/resources/bungee.yml
@@ -1,5 +1,5 @@
 name: TCPShield
-version: 2.8.0
+version: 2.8.1
 main: net.tcpshield.tcpshield.bungee.TCPShieldBungee
 author: https://tcpshield.com
 softdepends:

--- a/src/main/resources/bungee.yml
+++ b/src/main/resources/bungee.yml
@@ -1,5 +1,5 @@
 name: TCPShield
-version: 2.6.1
+version: 2.7.0
 main: net.tcpshield.tcpshield.bungee.TCPShieldBungee
 author: https://tcpshield.com
 softdepends:

--- a/src/main/resources/bungee.yml
+++ b/src/main/resources/bungee.yml
@@ -1,5 +1,5 @@
 name: TCPShield
-version: 2.7.0
+version: 2.8.0
 main: net.tcpshield.tcpshield.bungee.TCPShieldBungee
 author: https://tcpshield.com
 softdepends:

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -11,4 +11,4 @@ debug-mode: false
 enable-geyser-support: false
 
 # Spigot/Paper option only, does not affect bungeecord
-prefer-protocollib: true
+prefer-protocollib: false

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": 1,
   "id": "tcp-shield",
-  "version": "2.8.0",
+  "version": "2.8.1",
   "name": "TCPShield",
   "description": "TCPShield support for Fabric",
   "authors": [

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": 1,
   "id": "tcp-shield",
-  "version": "2.5",
+  "version": "2.8.0",
   "name": "TCPShield",
   "description": "TCPShield support for Fabric",
   "authors": [

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1,5 +1,5 @@
 name: TCPShield
-version: 2.6.1
+version: 2.7.0
 main: net.tcpshield.tcpshield.bukkit.TCPShieldBukkit
 softdepend:
 - ProtocolLib

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1,5 +1,5 @@
 name: TCPShield
-version: 2.8.0
+version: 2.8.1
 main: net.tcpshield.tcpshield.bukkit.TCPShieldBukkit
 softdepend:
 - ProtocolLib

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1,5 +1,5 @@
 name: TCPShield
-version: 2.7.0
+version: 2.8.0
 main: net.tcpshield.tcpshield.bukkit.TCPShieldBukkit
 softdepend:
 - ProtocolLib

--- a/src/main/resources/tcpshield.mixins.json
+++ b/src/main/resources/tcpshield.mixins.json
@@ -2,7 +2,7 @@
   "required": true,
   "minVersion": "0.8",
   "package": "net.tcpshield.tcpshield.fabric.mixin",
-  "compatibilityLevel": "JAVA_8",
+  "compatibilityLevel": "JAVA_17",
   "mixins": [
     "ClientConnectionAccessor",
     "HandshakeC2SPacketAccessor",

--- a/src/main/resources/velocity-plugin.json
+++ b/src/main/resources/velocity-plugin.json
@@ -1,7 +1,7 @@
 {
   "id": "tcpshield",
   "name": "TCPShield",
-  "version": "2.8.0",
+  "version": "2.8.1",
   "description": "TCPShield IP parsing capabilities for Velocity",
   "authors": [
     "TCPShield"

--- a/src/main/resources/velocity-plugin.json
+++ b/src/main/resources/velocity-plugin.json
@@ -1,1 +1,16 @@
-{"id":"tcpshield","name":"TCPShield","version":"2.6.1","description":"TCPShield IP parsing capabilities for Velocity","authors":["TCPShield"],"dependencies":[{"id":"floodgate","optional":true}],"main":"net.tcpshield.tcpshield.velocity.TCPShieldVelocity"}
+{
+  "id": "tcpshield",
+  "name": "TCPShield",
+  "version": "2.7.0",
+  "description": "TCPShield IP parsing capabilities for Velocity",
+  "authors": [
+    "TCPShield"
+  ],
+  "dependencies": [
+    {
+      "id": "floodgate",
+      "optional": true
+    }
+  ],
+  "main": "net.tcpshield.tcpshield.velocity.TCPShieldVelocity"
+}

--- a/src/main/resources/velocity-plugin.json
+++ b/src/main/resources/velocity-plugin.json
@@ -1,7 +1,7 @@
 {
   "id": "tcpshield",
   "name": "TCPShield",
-  "version": "2.7.0",
+  "version": "2.8.0",
   "description": "TCPShield IP parsing capabilities for Velocity",
   "authors": [
     "TCPShield"


### PR DESCRIPTION
Updates your PR to 1.21, the latest Fabric, and the latest RealIP. I don't know Java, so I apologise if there are certain things I've missed. https://github.com/TCPShield/RealIP/pull/91

Some further improvements that can be done (presuming you want to update the PR):
- It seems like the disconnect message doesn't work like on Paper; it just says 'Disconnected'
- The RealIP options aren't in their own folder in the server's `config`
- The way the logging is formatted is a bit barebones
- Pre 1.19 support probably doesn't work now

<details><summary>Logging example</summary>
<p>

```
Aug 01, 2024 3:25:24 PM net.tcpshield.tcpshield.fabric.TCPShieldFabric onInitializeServer
INFO: TCPShield has been loaded.
```

Instead of...

```
[15:25:24] [main/INFO]: TCPShield 2.8.1 has been loaded.
```

</p>
</details> 
